### PR TITLE
no-ACK SOM

### DIFF
--- a/ascii_protocol.c
+++ b/ascii_protocol.c
@@ -107,7 +107,7 @@ static char *control_types[]={
 ///////////////////////////////////////////////
 
 
-extern int protocol_post(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *len_bytes);
+extern int protocol_post(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg);
 
 // from protocol.c
 extern POSN Position;
@@ -748,8 +748,8 @@ void ascii_process_msg(PROTOCOL_STAT *s, char *cmd, int len){
                         break;
                     case 'T':
                     case 't':{
-                            char tmp[] = { 5, PROTOCOL_CMD_TEST, 'T', 'e', 's', 't' };
-                            protocol_post(s, (PROTOCOL_LEN_ONWARDS*)tmp);
+                            char tmp[] = { PROTOCOL_SOM_ACK, 0, 5, PROTOCOL_CMD_TEST, 'T', 'e', 's', 't' };
+                            protocol_post(s, (PROTOCOL_MSG2*)tmp);
                         }
                         break;
                 }

--- a/machine_protocol.c
+++ b/machine_protocol.c
@@ -237,7 +237,7 @@ int protocol_post(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *len_bytes){
     int total = len_bytes->len + 1; // +1 len
 
     if (txcount + total >= MACHINE_PROTOCOL_TX_BUFFER_SIZE-2) {
-        s->TxBuffer.overflow++;
+        s->TxBufferACK.overflow++;
         return -1;
     }
 
@@ -265,7 +265,7 @@ int protocol_send(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *len_bytes){
         memcpy(&s->curr_send_msg.len, len_bytes, len_bytes->len + 1);
     } else {
         // else try to send from queue
-        int ismsg = mpGetTxMsg(&s->TxBufferACK, &s->curr_send_msg_withAck.len);
+        int ismsg = mpGetTxMsg(&s->TxBufferACK, &s->curr_send_msg.len);
         if (ismsg){
             s->curr_send_msg.SOM = PROTOCOL_SOM;
             s->curr_send_msg.CI = CI;

--- a/protocol.c
+++ b/protocol.c
@@ -194,7 +194,7 @@ PROTOCOL_STAT sUSART3 = {
 #endif
 /////////////////////////////////////////////////////////////
 
-extern int protocol_post(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *len_bytes);
+extern int protocol_post(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg);
 
 
 //////////////////////////////////////////////
@@ -431,7 +431,7 @@ int paramcount = sizeof(params)/sizeof(params[0]);
 /////////////////////////////////////////////
 // a complete machineprotocl message has been
 // received without error
-void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *msg){
+void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
     PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) msg->bytes;
 
     switch (writevals->cmd){

--- a/protocol.h
+++ b/protocol.h
@@ -184,7 +184,7 @@ typedef struct tag_PROTOCOL_STAT {
     int (*send_serial_data)( unsigned char *data, int len );
     int (*send_serial_data_wait)( unsigned char *data, int len );
 
-    MACHINE_PROTOCOL_TX_BUFFER TxBuffer;
+    MACHINE_PROTOCOL_TX_BUFFER TxBufferACK;  // Buffer for Messages to be sent
 
 } PROTOCOL_STAT;
 
@@ -265,7 +265,7 @@ void protocol_init(PROTOCOL_STAT *s);
 /////////////////////////////////////////////////////////////////
 void ascii_byte(PROTOCOL_STAT *s, unsigned char byte );
 void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_LEN_ONWARDS *msg);
-int mpTxQueued(PROTOCOL_STAT *s);
+int mpTxQueued(MACHINE_PROTOCOL_TX_BUFFER *buf);
 
 //////////////////////////////////////////////////////////
 // Function pointer which can be set for "debugging"


### PR DESCRIPTION
see https://github.com/bipropellant/hbprotocol/issues/4 (https://github.com/orgs/bipropellant/projects/1#card-21024770)

Implement additional SOM to indicate Messages, which do not need to be acknowledged. Useful for information which is very time sensitive, like pmw set point and sensor data, where buffering during communication errors is not useful.
Reduces load on UART, Messages can also be sent quickly, even for some reason ACKs are not being sent or only RX is disturbed.

Allows very simple implementations, where one side can only send messages, but can not parse the replies.