### PR TITLE
Pass content of messages to helper functions, Add new UI_ types, Add read of params table

### DIFF
--- a/ascii_protocol.c
+++ b/ascii_protocol.c
@@ -584,14 +584,14 @@ void ascii_process_msg(PROTOCOL_STAT *s, char *cmd, int len){
                                 switch (params[i].ui_type){
                                     case UI_SHORT:
                                         // read it
-                                        if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, 0 );
+                                        if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, NULL, 0 );
                                         sprintf(ascii_out, "%s(%s): %d\r\n",
                                                 (params[i].description)?params[i].description:"",
                                                 params[i].uistr,
                                                 (int)*(short *)params[i].ptr);
                                         s->send_serial_data_wait((unsigned char *)ascii_out, strlen(ascii_out));
                                         ascii_out[0] = 0; // don't print last one twice
-                                        if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, 0 );
+                                        if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, NULL, 0 );
                                         break;
                                     default:
                                         break;
@@ -608,16 +608,16 @@ void ascii_process_msg(PROTOCOL_STAT *s, char *cmd, int len){
                                         case UI_SHORT:
                                             // if number supplied, write
                                             if ((cmd[1+strlen(params[i].uistr)] >= '0') && (cmd[1+strlen(params[i].uistr)] <= '9')){
-                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_WRITE, sizeof(short) );
+                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_WRITE, NULL, 0 );
                                                 *((short *)params[i].ptr) = atoi(&cmd[1+strlen(params[i].uistr)]);
-                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_WRITE, sizeof(short) );
+                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_WRITE, NULL, 0 );
                                                 sprintf(ascii_out, "flash var %s(%s) now %d\r\n",
                                                     (params[i].description)?params[i].description:"",
                                                     params[i].uistr,
                                                     (int)*(short *)params[i].ptr);
                                             } else {
                                                 // read it
-                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, 0 );
+                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, NULL, 0 );
                                                 sprintf(ascii_out, "%s(%s): %d\r\n",
                                                         (params[i].description)?params[i].description:"",
                                                         params[i].uistr,
@@ -625,7 +625,7 @@ void ascii_process_msg(PROTOCOL_STAT *s, char *cmd, int len){
                                                 );
                                                 s->send_serial_data_wait((unsigned char *)ascii_out, strlen(ascii_out));
                                                 ascii_out[0] = 0; // don't print last one twice
-                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, 0 );
+                                                if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, NULL, 0 );
                                             }
                                             break;
                                         default:

--- a/protocol.c
+++ b/protocol.c
@@ -519,33 +519,33 @@ void fn_xytPosn ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len )
 // NOTE: Don't start uistr with 'a'
 PARAMSTAT params[] = {
     // Protocol Relevant Parameters
-    { 0x00, NULL,                      NULL,  UI_NONE,  &version,                             sizeof(version),           PARAM_R,  NULL },
-    { 0x22, NULL,                      NULL,  UI_NONE,  &SubscribeData,                       sizeof(SubscribeData),     PARAM_RW, fn_SubscribeData },
-    { 0x23, NULL,                      NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataSum },
-    { 0x24, NULL,                      NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataAck },
-    { 0x25, NULL,                      NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataNoack },
+    { 0x00, "version",                 NULL,  UI_NONE,  &version,                             sizeof(version),           PARAM_R,  NULL },
+    { 0x22, "subscribe data",          NULL,  UI_NONE,  &SubscribeData,                       sizeof(SubscribeData),     PARAM_RW, fn_SubscribeData },
+    { 0x23, "protocol stats ack+noack", NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataSum },
+    { 0x24, "protocol stats ack",      NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataAck },
+    { 0x25, "protocol stats noack",    NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataNoack },
 
 #ifdef CONTROL_SENSOR
-    { 0x01, NULL,                      NULL,  UI_NONE,  &sensor_copy,                         sizeof(sensor_copy),       PARAM_R,  fn_SensorData },
+    { 0x01, "sensor data",             NULL,  UI_NONE,  &sensor_copy,                         sizeof(sensor_copy),       PARAM_R,  fn_SensorData },
 #endif
 #ifdef HALL_INTERRUPTS
-    { 0x02, NULL,                      NULL,  UI_NONE,  (void *)&HallData,                    sizeof(HallData),          PARAM_R,  NULL },
-    { 0x03, NULL,                      NULL,  UI_NONE,  &SpeedData,                           sizeof(SpeedData),         PARAM_RW, fn_SpeedData },
-    { 0x04, NULL,                      NULL,  UI_NONE,  &Position,                            sizeof(Position),          PARAM_RW, fn_Position },
-    { 0x05, NULL,                      NULL,  UI_NONE,  &PositionIncr,                        sizeof(PositionIncr),      PARAM_RW, fn_PositionIncr },
-    { 0x06, NULL,                      NULL,  UI_NONE,  &PosnData,                            sizeof(PosnData),          PARAM_RW, fn_preWriteClear },
-    { 0x07, NULL,                      NULL,  UI_NONE,  &RawPosition,                         sizeof(RawPosition),       PARAM_RW, fn_RawPosition },
+    { 0x02, "hall data",               NULL,  UI_NONE,  (void *)&HallData,                    sizeof(HallData),          PARAM_R,  NULL },
+    { 0x03, "speed control mm/s",      NULL,  UI_NONE,  &SpeedData,                           sizeof(SpeedData),         PARAM_RW, fn_SpeedData },
+    { 0x04, "hall position mm",        NULL,  UI_NONE,  &Position,                            sizeof(Position),          PARAM_RW, fn_Position },
+    { 0x05, "position control increment mm", NULL,  UI_NONE,  &PositionIncr,                        sizeof(PositionIncr),      PARAM_RW, fn_PositionIncr },
+    { 0x06, "position control mm",     NULL,  UI_NONE,  &PosnData,                            sizeof(PosnData),          PARAM_RW, fn_preWriteClear },
+    { 0x07, "hall position steps",     NULL,  UI_NONE,  &RawPosition,                         sizeof(RawPosition),       PARAM_RW, fn_RawPosition },
 #endif
-    { 0x08, NULL,                      NULL,  UI_NONE,  (void *)&electrical_measurements,     sizeof(ELECTRICAL_PARAMS), PARAM_R,  NULL },
-    { 0x09, NULL,                      NULL,  UI_NONE,  &enable,                              sizeof(enable),            PARAM_RW, fn_enable },
-    { 0x0A, NULL,                      NULL,  UI_NONE,  &disablepoweroff,                     sizeof(disablepoweroff),   PARAM_RW, fn_preWriteClear },
-    { 0x0B, NULL,                      NULL,  UI_NONE,  &debug_out,                           sizeof(debug_out),         PARAM_RW, fn_preWriteClear },
+    { 0x08, "electrical measurements", NULL,  UI_NONE,  (void *)&electrical_measurements,     sizeof(ELECTRICAL_PARAMS), PARAM_R,  NULL },
+    { 0x09, "enable motors",           NULL,  UI_NONE,  &enable,                              sizeof(enable),            PARAM_RW, fn_enable },
+    { 0x0A, "disable poweroff timer",  NULL,  UI_NONE,  &disablepoweroff,                     sizeof(disablepoweroff),   PARAM_RW, fn_preWriteClear },
+    { 0x0B, "enable console logs",     NULL,  UI_NONE,  &debug_out,                           sizeof(debug_out),         PARAM_RW, fn_preWriteClear },
 #ifndef EXCLUDE_DEADRECKONER
-    { 0x0C, NULL,                      NULL,  UI_NONE,  &xytPosn,                             sizeof(xytPosn),           PARAM_RW, fn_xytPosn },
+    { 0x0C, "read/clear xyt position", NULL,  UI_NONE,  &xytPosn,                             sizeof(xytPosn),           PARAM_RW, fn_xytPosn },
 #endif
-    { 0x0D, NULL,                      NULL,  UI_NONE,  &PWMData,                             sizeof(PWMData),           PARAM_RW, fn_PWMData },
-    { 0x0E, NULL,                      NULL,  UI_NONE,  &(PWMData.pwm),                       sizeof(PWMData.pwm),       PARAM_RW, fn_PWMData },
-    { 0x21, NULL,                      NULL,  UI_NONE,  &BuzzerData,                          sizeof(BuzzerData),        PARAM_RW, fn_BuzzerData },
+    { 0x0D, "PWM control",             NULL,  UI_NONE,  &PWMData,                             sizeof(PWMData),           PARAM_RW, fn_PWMData },
+    { 0x0E, "simpler PWM",             NULL,  UI_NONE,  &(PWMData.pwm),                       sizeof(PWMData.pwm),       PARAM_RW, fn_PWMData },
+    { 0x21, "buzzer",                  NULL,  UI_NONE,  &BuzzerData,                          sizeof(BuzzerData),        PARAM_RW, fn_BuzzerData },
 
 #ifdef FLASH_STORAGE
     { 0x80, "flash magic",             "m",   UI_SHORT, &FlashContent.magic,                  sizeof(short),             PARAM_RW, fn_FlashContentMagic },  // write this with CURRENT_MAGIC to commit to flash

--- a/protocol.c
+++ b/protocol.c
@@ -68,7 +68,7 @@ static SPEEDS speedsx = {0,0};
 // Default function, wipes receive memory before writing (and readresponse is just a differenct type of writing)
 
 
-void fn_preWriteClear ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_preWriteClear ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_WRITE:
         case FN_TYPE_PRE_READRESPONSE:
@@ -94,7 +94,7 @@ extern void init_PID_control();
 
 extern volatile ELECTRICAL_PARAMS electrical_measurements;
 
-void fn_FlashContentMagic ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_FlashContentMagic ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             if (FlashContent.magic != CURRENT_MAGIC){
@@ -110,7 +110,7 @@ void fn_FlashContentMagic ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type,
     }
 }
 
-void fn_FlashContentPID ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_FlashContentPID ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             change_PID_constants();
@@ -118,7 +118,7 @@ void fn_FlashContentPID ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, i
     }
 }
 
-void fn_FlashContentMaxCurrLim ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_FlashContentMaxCurrLim ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             electrical_measurements.dcCurLim = MIN(DC_CUR_LIMIT, FlashContent.MaxCurrLim / 100);
@@ -136,7 +136,7 @@ extern uint8_t enable; // global variable for motor enable
 //////////////////////////////////////////////
 // make values safe before we change enable...
 
-void fn_enable ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_enable ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_WRITE:
             if (!enable) {
@@ -172,7 +172,7 @@ extern SENSOR_DATA sensor_data[2];
 // used to send only pertinent data, not the whole structure
 SENSOR_FRAME sensor_copy[2];
 
-void fn_SensorData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_SensorData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
             // copy just sensor input data
@@ -202,7 +202,7 @@ SPEED_DATA SpeedData = {
     40 // minimum mm/s which we can ask for
 };
 
-void fn_SpeedData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_SpeedData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
             speedsx.speedl = ((SPEED_DATA*) (param->ptr))->wanted_speed_mm_per_sec[0];
@@ -222,7 +222,7 @@ void fn_SpeedData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len
 
 POSN Position;
 
-void fn_Position ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_Position ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
             ((POSN*) (param->ptr))->LeftAbsolute = HallData[0].HallPosn_mm;
@@ -243,7 +243,7 @@ void fn_Position ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len 
 
 POSN_INCR PositionIncr;
 
-void fn_PositionIncr ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_PositionIncr ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             // if switching to control type POSITION,
@@ -251,7 +251,7 @@ void fn_PositionIncr ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int 
                 control_type = CONTROL_TYPE_POSITION;
                 // then make sure we won't rush off somwehere strange
                 // by setting our wanted posn to where we currently are...
-                fn_enable( s, param, FN_TYPE_PRE_WRITE, 0); // TODO: I don't like calling this with a param entry which does not fit to the handler..
+                fn_enable( s, param, FN_TYPE_PRE_WRITE, content, 0); // TODO: I don't like calling this with a param entry which does not fit to the handler..
             }
 
             enable = 1;
@@ -281,7 +281,7 @@ POSN_DATA PosnData = {
 POSN RawPosition;
 
 
-void fn_RawPosition ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_RawPosition ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
             ((POSN*) (param->ptr))->LeftAbsolute = HallData[0].HallPosn;
@@ -331,7 +331,7 @@ PWM_DATA PWMData = {
 
 extern int pwms[2];
 
-void fn_PWMData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_PWMData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_PRE_READRESPONSE:
         case FN_TYPE_PRE_WRITE:
@@ -372,7 +372,7 @@ extern uint8_t buzzerFreq;    // global variable for the buzzer pitch. can be 1,
 extern uint8_t buzzerPattern; // global variable for the buzzer pattern. can be 1, 2, 3, 4, 5, 6, 7...
 extern uint16_t buzzerLen;
 
-void fn_BuzzerData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_BuzzerData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             buzzerFreq      = ((BUZZER_DATA*) (param->ptr))->buzzerFreq;
@@ -393,9 +393,9 @@ void fn_BuzzerData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int le
 
 SUBSCRIBEDATA SubscribeData =  { .code=0, .period=0, .count=0, .som=0 };
 
-void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
 
-    fn_preWriteClear(s, param, fn_type, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
+    fn_preWriteClear(s, param, fn_type, content, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
 
     switch (fn_type) {
 
@@ -443,9 +443,9 @@ void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int
 
 PROTOCOLCOUNT ProtocolcountData =  { .rx = 0 };
 
-void fn_ProtocolcountDataSum ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_ProtocolcountDataSum ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
 
-    fn_preWriteClear(s, param, fn_type, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
+    fn_preWriteClear(s, param, fn_type, content, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
 
     switch (fn_type) {
 
@@ -468,9 +468,9 @@ void fn_ProtocolcountDataSum ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_ty
     }
 }
 
-void fn_ProtocolcountDataAck ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_ProtocolcountDataAck ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
 
-    fn_preWriteClear(s, param, fn_type, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
+    fn_preWriteClear(s, param, fn_type, content, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
 
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
@@ -483,9 +483,9 @@ void fn_ProtocolcountDataAck ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_ty
     }
 }
 
-void fn_ProtocolcountDataNoack ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ) {
+void fn_ProtocolcountDataNoack ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
 
-    fn_preWriteClear(s, param, fn_type, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
+    fn_preWriteClear(s, param, fn_type, content, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
 
     switch (fn_type) {
         case FN_TYPE_PRE_READ:
@@ -500,7 +500,7 @@ void fn_ProtocolcountDataNoack ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_
 
 #ifndef EXCLUDE_DEADRECKONER
 
-void fn_xytPosn ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len ){
+void fn_xytPosn ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ){
     switch (fn_type) {
         case FN_TYPE_POST_WRITE:
             if (deadreconer) {
@@ -579,7 +579,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
             int i;
             for (i = 0; i < sizeof(params)/sizeof(params[0]); i++){
                 if (params[i].code == writevals->code){
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, msg->len-2 ); // NOTE: re-uses the msg object (part of stats)
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READ, writevals->content, msg->len-2 ); // NOTE: re-uses the msg object (part of stats)
                     unsigned char *src = params[i].ptr;
                     for (int j = 0; j < params[i].len; j++){
                         writevals->content[j] = *(src++);
@@ -588,7 +588,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
                     writevals->cmd = PROTOCOL_CMD_READVALRESPONSE; // mark as response
                     // send back with 'read' command plus data like write.
                     protocol_post(s, msg);
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, msg->len-2 );
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READ, writevals->content, msg->len-2 );
                     break;
                 }
             }
@@ -606,7 +606,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
             int i;
             for (i = 0; i < sizeof(params)/sizeof(params[0]); i++){
                 if (params[i].code == writevals->code){
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READRESPONSE, msg->len-2 );
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_READRESPONSE, writevals->content, msg->len-2 );
 
                     unsigned char *dest = params[i].ptr;
                     // ONLY copy what we have, else we're stuffing random data in.
@@ -615,7 +615,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
                     for (int j = 0; ((j < params[i].len) && (j < (msg->len-2))); j++){
                         *(dest++) = writevals->content[j];
                     }
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READRESPONSE, msg->len-2 );
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_READRESPONSE, writevals->content,  msg->len-2 );
                     break;
                 }
             }
@@ -643,7 +643,8 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
                     s->ack.counters.unplausibleresponse++;
                 } else {
                     s->noack.counters.unplausibleresponse++;
-                }                        }
+                }                        
+            }
             break;
         }
 
@@ -651,7 +652,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
             int i;
             for (i = 0; i < sizeof(params)/sizeof(params[0]); i++){
                 if (params[i].code == writevals->code){
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_WRITE, msg->len-2 );
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_PRE_WRITE, writevals->content, msg->len-2 );
                     // NOTE: re-uses the msg object (part of stats)
                     unsigned char *dest = params[i].ptr;
 
@@ -666,7 +667,7 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
                     writevals->content[0] = 1; // say we wrote it
                     // send back with 'write' command with no data.
                     protocol_post(s, msg);
-                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_WRITE, msg->len-2 );
+                    if (params[i].fn) params[i].fn( s, &params[i], FN_TYPE_POST_WRITE, writevals->content, msg->len-2 );
                     break;
                 }
             }

--- a/protocol.c
+++ b/protocol.c
@@ -608,7 +608,7 @@ void fn_paramstat_descriptions ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_
 PARAMSTAT params[] = {
     // Protocol Relevant Parameters
     { 0xFF, "descriptions",            NULL,  UI_NONE,  &paramstat_descriptions,              0,                         PARAM_R,  fn_paramstat_descriptions },
-    { 0x00, "version",                 NULL,  UI_NONE,  &version,                             sizeof(version),           PARAM_R,  NULL },
+    { 0x00, "version",                 NULL,  UI_LONG,  &version,                             sizeof(version),           PARAM_R,  NULL },
     { 0x22, "subscribe data",          NULL,  UI_NONE,  &SubscribeData,                       sizeof(SubscribeData),     PARAM_RW, fn_SubscribeData },
     { 0x23, "protocol stats ack+noack", NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataSum },
     { 0x24, "protocol stats ack",      NULL,  UI_NONE,  &ProtocolcountData,                   sizeof(PROTOCOLCOUNT),     PARAM_RW, fn_ProtocolcountDataAck },
@@ -626,14 +626,14 @@ PARAMSTAT params[] = {
     { 0x07, "hall position steps",     NULL,  UI_NONE,  &RawPosition,                         sizeof(RawPosition),       PARAM_RW, fn_RawPosition },
 #endif
     { 0x08, "electrical measurements", NULL,  UI_NONE,  (void *)&electrical_measurements,     sizeof(ELECTRICAL_PARAMS), PARAM_R,  NULL },
-    { 0x09, "enable motors",           NULL,  UI_NONE,  &enable,                              sizeof(enable),            PARAM_RW, fn_enable },
-    { 0x0A, "disable poweroff timer",  NULL,  UI_NONE,  &disablepoweroff,                     sizeof(disablepoweroff),   PARAM_RW, fn_preWriteClear },
-    { 0x0B, "enable console logs",     NULL,  UI_NONE,  &debug_out,                           sizeof(debug_out),         PARAM_RW, fn_preWriteClear },
+    { 0x09, "enable motors",           NULL,  UI_CHAR,  &enable,                              sizeof(enable),            PARAM_RW, fn_enable },
+    { 0x0A, "disable poweroff timer",  NULL,  UI_CHAR,  &disablepoweroff,                     sizeof(disablepoweroff),   PARAM_RW, fn_preWriteClear },
+    { 0x0B, "enable console logs",     NULL,  UI_CHAR,  &debug_out,                           sizeof(debug_out),         PARAM_RW, fn_preWriteClear },
 #ifndef EXCLUDE_DEADRECKONER
-    { 0x0C, "read/clear xyt position", NULL,  UI_NONE,  &xytPosn,                             sizeof(xytPosn),           PARAM_RW, fn_xytPosn },
+    { 0x0C, "read/clear xyt position", NULL,  UI_3LONG, &xytPosn,                             sizeof(xytPosn),           PARAM_RW, fn_xytPosn },
 #endif
     { 0x0D, "PWM control",             NULL,  UI_NONE,  &PWMData,                             sizeof(PWMData),           PARAM_RW, fn_PWMData },
-    { 0x0E, "simpler PWM",             NULL,  UI_NONE,  &(PWMData.pwm),                       sizeof(PWMData.pwm),       PARAM_RW, fn_PWMData },
+    { 0x0E, "simpler PWM",             NULL,  UI_2LONG, &(PWMData.pwm),                       sizeof(PWMData.pwm),       PARAM_RW, fn_PWMData },
     { 0x21, "buzzer",                  NULL,  UI_NONE,  &BuzzerData,                          sizeof(BuzzerData),        PARAM_RW, fn_BuzzerData },
 
 #ifdef FLASH_STORAGE

--- a/protocol.c
+++ b/protocol.c
@@ -545,10 +545,10 @@ void fn_paramstat_descriptions ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_
             // we prepare a buffer here, an MODIFY the paramstat length to tell it how much to send! (evil!?).
             int first = 0;
             int count = 100;
-            if (len > 1) {
+            if (len > 0) {
                 first = content[0];
             }
-            if (len > 2) {
+            if (len > 1) {
                 count = content[1];
             }
 

--- a/protocol.h
+++ b/protocol.h
@@ -260,6 +260,7 @@ typedef struct tag_PROTOCOL_STAT {
 #define UI_2SHORT 0x22
 #define UI_2LONG 0x24
 #define UI_2LONGLONG 0x28
+#define UI_3LONG 0x34
 // e.g.
 // #define UI_8CHAR 0x81
 // #define UI_POSN 0x03 - custom structure type.

--- a/protocol.h
+++ b/protocol.h
@@ -244,9 +244,25 @@ typedef struct tag_PROTOCOL_STAT {
 #define PARAM_R     1
 #define PARAM_RW    3
 ///////////////////////////////////////////////////
+// defines for simple variable types.
+// generally: 
+// if first nibble is 1, second nibble is bytecount for single variable.
+// if second nibble is 2, second nibble is bytecount for each of two variables.
+// etc.
+// if 2nd nibble is NOT a power of 2, all bets off -> custom type (note 2^0 = 1)
+// these are as yet not implemented....
 #define UI_NONE 0
-#define UI_SHORT 1
-
+#define UI_CHAR 0x11
+#define UI_SHORT 0x12
+#define UI_LONG 0x14
+#define UI_LONGLONG 0x18
+#define UI_2CHAR 0x21
+#define UI_2SHORT 0x22
+#define UI_2LONG 0x24
+#define UI_2LONGLONG 0x28
+// e.g.
+// #define UI_8CHAR 0x81
+// #define UI_POSN 0x03 - custom structure type.
 
 #define FN_TYPE_PRE_READ          1
 #define FN_TYPE_POST_READ         2

--- a/protocol.h
+++ b/protocol.h
@@ -259,7 +259,8 @@ typedef struct tag_PROTOCOL_STAT {
 struct tag_PARAMSTAT;
 typedef struct tag_PARAMSTAT PARAMSTAT;
 
-typedef void (*PARAMSTAT_FN)( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, int len );
+// NOTE: content can be NULL if len == 0
+typedef void (*PARAMSTAT_FN)( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len );
 
 
 struct tag_PARAMSTAT {


### PR DESCRIPTION
ok, so whilst updating the wiki, I was thinking about how to make the protocol a little more accessible.  Thought that ability to read information ABOUT the protocol, using the protocol, may be useful; how useful I'm not entirely sure.
Anyway, that lead me to this PR.

Main features:
1/ it passes the msg content to the helper functions, as well as the content len.  This allows us to pass parameters into read - for example to read an entry in an array (what i needed to read the params entries).
2/ Adds more UI_ defines, and a suggested structure for how to define them.
3/ adds human descriptions for each params entry (make it easier to get into?).
4/ adds a params entry which allows you to read (using the protocol) entries from the params table, getting variable type (UI_ define), variable size, and description.  You can read from a 'first' entry for a count, and it will try to fill a message, which will include first, and the actual count it fitted in.

I'm not sure 4/ is actually useful (unless more variables are of simple type), but it's a good illustration of use of the new content passing.

@p-h-a-i-l  - your thoughts; as you use this at both ends....  I've tested, and the protocol still works :), as does the new function