### PR TITLE
Communication disconnection timeout implementation

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -64,7 +64,9 @@ typedef struct tag_SPEEDS{
 static SPEEDS speedsx = {0,0};
 
 
-
+#ifdef INPUT_TIMEOUT
+extern volatile uint32_t input_timeout;
+#endif // DEBUG
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -215,6 +217,11 @@ void fn_SpeedData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigne
         case FN_TYPE_PRE_WRITE:
             control_type = CONTROL_TYPE_SPEED;
             timeout = 0;
+            
+  #ifdef INPUT_TIMEOUT
+            input_timeout = 0;
+            #endif
+
             break;
     }
 }
@@ -259,7 +266,9 @@ void fn_PositionIncr ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsi
 
             enable = 1;
             timeout = 0;
-
+  #ifdef INPUT_TIMEOUT
+            input_timeout = 0;
+            #endif
             // increment our wanted position
             PosnData.wanted_posn_mm[0] += ((POSN_INCR*) (param->ptr))->Left;
             PosnData.wanted_posn_mm[1] += ((POSN_INCR*) (param->ptr))->Right;
@@ -340,6 +349,9 @@ void fn_PWMData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned 
         case FN_TYPE_PRE_WRITE:
             control_type = CONTROL_TYPE_PWM;
             timeout = 0;
+              #ifdef INPUT_TIMEOUT
+            input_timeout = 0;
+            #endif
             break;
 
         case FN_TYPE_POST_READRESPONSE:

--- a/protocol.c
+++ b/protocol.c
@@ -217,8 +217,9 @@ void fn_SpeedData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigne
         case FN_TYPE_PRE_WRITE:
             control_type = CONTROL_TYPE_SPEED;
             timeout = 0;
-            
+          
   #ifdef INPUT_TIMEOUT
+    enable=1;
             input_timeout = 0;
             #endif
 
@@ -264,10 +265,11 @@ void fn_PositionIncr ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsi
                 fn_enable( s, param, FN_TYPE_PRE_WRITE, content, 0); // TODO: I don't like calling this with a param entry which does not fit to the handler..
             }
 
-            enable = 1;
+          
             timeout = 0;
   #ifdef INPUT_TIMEOUT
             input_timeout = 0;
+              enable = 1;
             #endif
             // increment our wanted position
             PosnData.wanted_posn_mm[0] += ((POSN_INCR*) (param->ptr))->Left;
@@ -349,7 +351,9 @@ void fn_PWMData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned 
         case FN_TYPE_PRE_WRITE:
             control_type = CONTROL_TYPE_PWM;
             timeout = 0;
+             
               #ifdef INPUT_TIMEOUT
+               enable=1;
             input_timeout = 0;
             #endif
             break;


### PR DESCRIPTION
I have made that when you disconnect your device from hoverboard, it could either slow down or make hard stop.
Soft stop is enabled by default. Timeout value is configurable, as well as enabling HARD stop. Everything can be changed in either config.h or platformio.ini

This feature is used with Position/Speed/PWM controls and with UART2/UART3/SOft communications.

Here is demonstration video:
https://photos.app.goo.gl/V6zawA2GK3L7XRNs5