### PR TITLE
64 bit support

### DIFF
--- a/ascii_protocol.h
+++ b/ascii_protocol.h
@@ -19,3 +19,12 @@
 #pragma once
 
 #include "protocol_private.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/machine_protocol.c
+++ b/machine_protocol.c
@@ -24,15 +24,17 @@
 * call protocol_post to send a message
 */
 
-#include "stm32f1xx_hal.h"
-#include "config.h"
 #include "protocol_private.h"
 
 #include <string.h>
 #include <stdlib.h>
 
-#if (INCLUDE_PROTOCOL == INCLUDE_PROTOCOL2)
 
+
+// if not using from STM32, provide dummy functions from your project...
+extern void (*HAL_Delay)(uint32_t Delay);
+extern void (*HAL_NVIC_SystemReset)(void);
+extern uint32_t (*HAL_GetTick)(void);
 
 
 
@@ -519,6 +521,3 @@ void mpPutTx(MACHINE_PROTOCOL_TX_BUFFER *buf, unsigned char value){
     buf->buff[buf->head] = value;
     buf->head = ((buf->head + 1 ) % MACHINE_PROTOCOL_TX_BUFFER_SIZE);
 }
-
-
-#endif // INCLUDE_PROTOCOL2

--- a/machine_protocol.c
+++ b/machine_protocol.c
@@ -31,11 +31,6 @@
 
 
 
-// if not using from STM32, provide dummy functions from your project...
-extern void (*HAL_Delay)(uint32_t Delay);
-extern void (*HAL_NVIC_SystemReset)(void);
-extern uint32_t (*HAL_GetTick)(void);
-
 
 
 static unsigned char mpGetTxByte(MACHINE_PROTOCOL_TX_BUFFER *buf);
@@ -74,7 +69,7 @@ void protocol_byte(PROTOCOL_STAT *s, unsigned char byte ){
     case PROTOCOL_STATE_IDLE:
         if ((byte == PROTOCOL_SOM_ACK) || (byte == PROTOCOL_SOM_NOACK)){
             s->curr_msg.SOM = byte;
-            s->last_char_time = HAL_GetTick();
+            s->last_char_time = protocol_GetTick();
             s->state = PROTOCOL_STATE_WAIT_CI;
             s->CS = 0;
         } else {
@@ -85,21 +80,21 @@ void protocol_byte(PROTOCOL_STAT *s, unsigned char byte ){
                 ascii_byte(s, byte );
                 //////////////////////////////////////////////////////
             } else {
-                s->last_char_time = HAL_GetTick();
+                s->last_char_time = protocol_GetTick();
                 s->state = PROTOCOL_STATE_BADCHAR;
             }
         }
         break;
 
     case PROTOCOL_STATE_WAIT_CI:
-        s->last_char_time = HAL_GetTick();
+        s->last_char_time = protocol_GetTick();
         s->curr_msg.CI = byte;
         s->CS += byte;
         s->state = PROTOCOL_STATE_WAIT_LEN;
         break;
 
     case PROTOCOL_STATE_WAIT_LEN:
-        s->last_char_time = HAL_GetTick();
+        s->last_char_time = protocol_GetTick();
         s->curr_msg.len = byte;
         s->count = 0;
         s->CS += byte;
@@ -107,7 +102,7 @@ void protocol_byte(PROTOCOL_STAT *s, unsigned char byte ){
         break;
 
     case PROTOCOL_STATE_WAIT_END:
-        s->last_char_time = HAL_GetTick();
+        s->last_char_time = protocol_GetTick();
         s->curr_msg.bytes[s->count++] = byte;
         s->CS += byte;
 
@@ -147,7 +142,7 @@ void protocol_byte(PROTOCOL_STAT *s, unsigned char byte ){
                         if (s->ack.retries > 0){
                             s->ack.counters.txRetries++;
                             protocol_send_raw(s->send_serial_data, &s->ack.curr_send_msg);
-                            s->ack.last_send_time = HAL_GetTick();
+                            s->ack.last_send_time = protocol_GetTick();
                             s->ack.retries--;
                         } else {
                             s->send_state = PROTOCOL_ACK_TX_IDLE;
@@ -328,7 +323,7 @@ int protocol_send(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
             s->ack.counters.tx++;
             protocol_send_raw(s->send_serial_data, &s->ack.curr_send_msg);
             s->send_state = PROTOCOL_ACK_TX_WAITING;
-            s->ack.last_send_time = HAL_GetTick();
+            s->ack.last_send_time = protocol_GetTick();
             s->ack.retries = 2;
             return 0;
 
@@ -355,7 +350,7 @@ int protocol_send(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg){
             s->ack.counters.tx++;
             protocol_send_raw(s->send_serial_data, &s->ack.curr_send_msg);
             s->send_state = PROTOCOL_ACK_TX_WAITING;
-            s->ack.last_send_time = HAL_GetTick();
+            s->ack.last_send_time = protocol_GetTick();
             s->ack.retries = 2;
             return 0;
 
@@ -398,7 +393,7 @@ void protocol_send_raw(int (*send_serial_data)( unsigned char *data, int len ), 
 // called regularly from main.c
 // externed from protocol.h
 void protocol_tick(PROTOCOL_STAT *s){
-    s->last_tick_time = HAL_GetTick();
+    s->last_tick_time = protocol_GetTick();
 
 
     if(s->send_state == PROTOCOL_ACK_TX_WAITING) {
@@ -407,7 +402,7 @@ void protocol_tick(PROTOCOL_STAT *s){
             if (s->ack.retries > 0){
                 s->ack.counters.txRetries++;
                 protocol_send_raw(s->send_serial_data, &s->ack.curr_send_msg);
-                s->ack.last_send_time = HAL_GetTick();
+                s->ack.last_send_time = protocol_GetTick();
                 s->ack.retries--;
             } else {
                 // if we run out of retries, then try to send a next message

--- a/protocol.c
+++ b/protocol.c
@@ -22,10 +22,19 @@
 #include <stdlib.h>
 
 
-// if not using from STM32, provide dummy functions from your project...
-extern void (*HAL_Delay)(uint32_t Delay);
-extern void (*HAL_NVIC_SystemReset)(void);
-extern uint32_t (*HAL_GetTick)(void);
+///////////////////////////////////////////////////////
+// Function Pointers to system functions
+//////////////////////////////////////////////////////////
+
+// Need to be assigned to functions "real" system fucntions
+uint32_t noTick(void) { return 0; };
+uint32_t (*protocol_GetTick)() = noTick;
+
+void noDelay(uint32_t Delay) {};
+void (*protocol_Delay)(uint32_t Delay) = noDelay;
+
+void noReset(void) {};
+void (*protocol_SystemReset)() = noReset;
 
 
 
@@ -514,8 +523,8 @@ void protocol_process_message(PROTOCOL_STAT *s, PROTOCOL_MSG2 *msg) {
 
         case PROTOCOL_CMD_REBOOT:
             //protocol_send_ack(); // we no longer ack from here
-            HAL_Delay(500);
-            HAL_NVIC_SystemReset();
+            protocol_Delay(500);
+            protocol_SystemReset();
             break;
 
         case PROTOCOL_CMD_TEST:

--- a/protocol.c
+++ b/protocol.c
@@ -23,8 +23,10 @@
 
 
 // if not using from STM32, provide dummy functions from your project...
-extern int HAL_Delay(int ms);
-extern int HAL_NVIC_SystemReset();
+extern void (*HAL_Delay)(uint32_t Delay);
+extern void (*HAL_NVIC_SystemReset)(void);
+extern uint32_t (*HAL_GetTick)(void);
+
 
 
 static int initialised_functions = 0;
@@ -62,8 +64,6 @@ static int version = 1;
 ////////////////////////////////////////////////////////////////////////////////////////////
 // Variable & Functions for 0x22 SubscribeData
 
-PROTOCOL_SUBSCRIBEDATA SubscribeData =  { .code=0, .period=0, .count=0, .som=0 };
-
 void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, unsigned char *content, int len ) {
 
     fn_preWriteClear(s, param, fn_type, content, len); // Wipes memory before write (and readresponse is just a differenct type of writing)
@@ -72,20 +72,25 @@ void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, uns
 
         case FN_TYPE_POST_WRITE:
         case FN_TYPE_POST_READRESPONSE:
-            ;     // empty statement, labels must not be followed by declarations..
-            int len = sizeof(s->subscriptions)/sizeof(s->subscriptions[0]);
+
+            // Check if length of received data is plausible.
+            if(len != sizeof(PROTOCOL_SUBSCRIBEDATA)) {
+                break;
+            }
+
+            int subscriptions_len = sizeof(s->subscriptions)/sizeof(s->subscriptions[0]);
             int index = 0;
 
             // Check if subscription already exists for this code
-            for (index = 0; index < len; index++) {
-                if(s->subscriptions[index].code == ((PROTOCOL_SUBSCRIBEDATA*) (param->ptr))->code) {
+            for (index = 0; index < subscriptions_len; index++) {
+                if(s->subscriptions[index].code == ((PROTOCOL_SUBSCRIBEDATA*) content)->code) {
                     break;
                 }
             }
 
             // If code was not found, look for vacant subscription slot
-            if(index == len) {
-                for (index = 0; index < len; index++) {
+            if(index == subscriptions_len) {
+                for (index = 0; index < subscriptions_len; index++) {
                     // NOTE: if you set a count of 0, or the count runs out, then
                     // the subscription will be overwritten later -
                     // i.e. you effectively delete it....
@@ -96,8 +101,8 @@ void fn_SubscribeData ( PROTOCOL_STAT *s, PARAMSTAT *param, uint8_t fn_type, uns
             }
 
             // Fill in new subscription when possible; Plausibility check for period
-            if(index < len && ((PROTOCOL_SUBSCRIBEDATA*) (param->ptr))->period >= 10) {
-                s->subscriptions[index] = *((PROTOCOL_SUBSCRIBEDATA*) (param->ptr));
+            if(index < subscriptions_len && ((PROTOCOL_SUBSCRIBEDATA*) content)->period >= 10) {
+                s->subscriptions[index] = *((PROTOCOL_SUBSCRIBEDATA*) content);
                 //char tmp[100];
                 //sprintf(tmp, "subscription added at %d for 0x%x, period %d, count %d, som %d\n", index, ((SUBSCRIBEDATA*) (param->ptr))->code, ((SUBSCRIBEDATA*) (param->ptr))->period, ((SUBSCRIBEDATA*) (param->ptr))->count, ((SUBSCRIBEDATA*) (param->ptr))->som);
                 //consoleLog(tmp);
@@ -265,12 +270,12 @@ PARAMSTAT *params[256];
 
 PARAMSTAT initialparams[] = {
     // Protocol Relevant Parameters
-    { 0xFF, "descriptions",            NULL,  UI_NONE,  &paramstat_descriptions, 0,                 PARAM_R,  fn_paramstat_descriptions },
-    { 0x00, "version",                 NULL,  UI_LONG,  &version,           sizeof(int),            PARAM_R,  NULL },
-    { 0x22, "subscribe data",          NULL,  UI_NONE,  &SubscribeData,     sizeof(PROTOCOL_SUBSCRIBEDATA),  PARAM_RW, fn_SubscribeData },
-    { 0x23, "protocol stats ack+noack",NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),  PARAM_RW, fn_ProtocolcountDataSum },
-    { 0x24, "protocol stats ack",      NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),  PARAM_RW, fn_ProtocolcountDataAck },
-    { 0x25, "protocol stats noack",    NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),  PARAM_RW, fn_ProtocolcountDataNoack },
+    { 0xFF, "descriptions",            NULL,  UI_NONE,  &paramstat_descriptions, 0,                         PARAM_R,  fn_paramstat_descriptions },
+    { 0x00, "version",                 NULL,  UI_LONG,  &version,           sizeof(int),                    PARAM_R,  NULL },
+    { 0x22, "subscribe data",          NULL,  UI_NONE,  &contentbuf,        sizeof(PROTOCOL_SUBSCRIBEDATA), PARAM_RW, fn_SubscribeData },
+    { 0x23, "protocol stats ack+noack",NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),          PARAM_RW, fn_ProtocolcountDataSum },
+    { 0x24, "protocol stats ack",      NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),          PARAM_RW, fn_ProtocolcountDataAck },
+    { 0x25, "protocol stats noack",    NULL,  UI_NONE,  &ProtocolcountData, sizeof(PROTOCOLCOUNT),          PARAM_RW, fn_ProtocolcountDataNoack },
 
     // Sensor (Hoverboard mode)
     { 0x01, "sensor data",             NULL,  UI_NONE,  &contentbuf, sizeof(PROTOCOL_SENSOR_FRAME),          PARAM_R,  NULL },
@@ -283,9 +288,9 @@ PARAMSTAT initialparams[] = {
     { 0x06, "position control mm",     NULL,  UI_NONE,  &contentbuf, sizeof(PROTOCOL_POSN_DATA),             PARAM_RW, fn_preWriteClear },
     { 0x07, "hall position steps",     NULL,  UI_NONE,  &contentbuf, sizeof(PROTOCOL_POSN),                  PARAM_RW, fn_preWriteClear },
     { 0x08, "electrical measurements", NULL,  UI_NONE,  &contentbuf, sizeof(PROTOCOL_ELECTRICAL_PARAMS),     PARAM_R,  NULL },
-    { 0x09, "enable motors",           NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t),               PARAM_RW, fn_preWriteClear },
-    { 0x0A, "disable poweroff timer",  NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t),               PARAM_RW, fn_preWriteClear },
-    { 0x0B, "enable console logs",     NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t ),              PARAM_RW, fn_preWriteClear },
+    { 0x09, "enable motors",           NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t),                        PARAM_RW, fn_preWriteClear },
+    { 0x0A, "disable poweroff timer",  NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t),                        PARAM_RW, fn_preWriteClear },
+    { 0x0B, "enable console logs",     NULL,  UI_CHAR,  &contentbuf, sizeof(uint8_t ),                       PARAM_RW, fn_preWriteClear },
     { 0x0C, "read/clear xyt position", NULL,  UI_3LONG, &contentbuf, sizeof(PROTOCOL_INTEGER_XYT_POSN),      PARAM_RW, fn_preWriteClear },
     { 0x0D, "PWM control",             NULL,  UI_NONE,  &contentbuf, sizeof(PROTOCOL_PWM_DATA),              PARAM_RW, fn_preWriteClear },
     { 0x0E, "simpler PWM",             NULL,  UI_2LONG, &contentbuf, sizeof( ((PROTOCOL_PWM_DATA *)0)->pwm), PARAM_RW, fn_preWriteClear },

--- a/protocol.h
+++ b/protocol.h
@@ -28,15 +28,15 @@ extern "C" {
 #pragma pack(push, 4)  // all used data types are 4 byte
 typedef struct tag_PROTOCOL_POSN_DATA {
     // these get set
-    long wanted_posn_mm[2];
+    int32_t wanted_posn_mm[2];
 
     // configurations/constants
-    int posn_max_speed; // max speed in this mode
-    int posn_min_speed; // minimum speed (to get wheels moving)
+    int32_t posn_max_speed; // max speed in this mode
+    int32_t posn_min_speed; // minimum speed (to get wheels moving)
 
     // just so it can be read back
-    long posn_diff_mm[2];
-    long posn_speed_demand[2];
+    int32_t posn_diff_mm[2];
+    int32_t posn_speed_demand[2];
 } PROTOCOL_POSN_DATA;
 #pragma pack(pop)
 
@@ -44,16 +44,16 @@ typedef struct tag_PROTOCOL_POSN_DATA {
 #pragma pack(push, 4)  // all used data types are 4 byte
 typedef struct tag_PROTOCOL_SPEED_DATA {
     // these get set
-    long wanted_speed_mm_per_sec[2];
+    int32_t wanted_speed_mm_per_sec[2];
 
     // configurations/constants
-    int speed_max_power; // max speed in this mode
-    int speed_min_power; // minimum speed (to get wheels moving)
-    int speed_minimum_speed; // below this, we don't ask it to do anything
+    int32_t speed_max_power; // max speed in this mode
+    int32_t speed_min_power; // minimum speed (to get wheels moving)
+    int32_t speed_minimum_speed; // below this, we don't ask it to do anything
 
     // just so it can be read back
-    long speed_diff_mm_per_sec[2];
-    long speed_power_demand[2];
+    int32_t speed_diff_mm_per_sec[2];
+    int32_t speed_power_demand[2];
 } PROTOCOL_SPEED_DATA;
 #pragma pack(pop)
 
@@ -61,12 +61,12 @@ typedef struct tag_PROTOCOL_SPEED_DATA {
 #pragma pack(push, 4)  // all used data types are 4 byte
 typedef struct tag_PROTOCOL_PWM_DATA {
     // these get set
-    long pwm[2];
+    int32_t pwm[2];
 
     // configurations/constants
-    int speed_max_power; // max speed in this mode
-    int speed_min_power; // minimum speed (to get wheels moving)
-    int speed_minimum_pwm; // below this, we don't ask it to do anything
+    int32_t speed_max_power; // max speed in this mode
+    int32_t speed_min_power; // minimum speed (to get wheels moving)
+    int32_t speed_minimum_pwm; // below this, we don't ask it to do anything
 } PROTOCOL_PWM_DATA;
 #pragma pack(pop)
 
@@ -74,18 +74,18 @@ typedef struct tag_PROTOCOL_PWM_DATA {
 
 #pragma pack(push, 4)  // long and float are 4 byte each
 typedef struct tag_PROTOCOL_HALL_DATA_STRUCT{
-    long HallPosn; // 90 per revolution
-    long HallSpeed; // speed part calibrated to speed demand value
+    int32_t HallPosn; // 90 per revolution
+    int32_t HallSpeed; // speed part calibrated to speed demand value
 
     float HallPosnMultiplier; // m per hall segment
 
-    long HallPosn_lastread; // posn offset set via protocol in raw value
-    long HallPosn_mm; // posn in mm
-    long HallPosn_mm_lastread; // posn offset set via protocol in mm
-    long HallSpeed_mm_per_s; // speed in m/s
+    int32_t HallPosn_lastread; // posn offset set via protocol in raw value
+    int32_t HallPosn_mm; // posn in mm
+    int32_t HallPosn_mm_lastread; // posn offset set via protocol in mm
+    int32_t HallSpeed_mm_per_s; // speed in m/s
 
-    unsigned long HallTimeDiff;
-    unsigned long HallSkipped;
+    uint32_t HallTimeDiff;
+    uint32_t HallSkipped;
 } PROTOCOL_HALL_DATA_STRUCT;
 #pragma pack(pop)
 
@@ -95,33 +95,33 @@ typedef struct tag_PROTOCOL_MOTOR_ELECTRICAL{
         float dcAmps;
         float dcAmpsAvgAcc;
         float dcAmpsAvg;
-        int r1;
-        int r2;
-        int q;
+        int32_t r1;
+        int32_t r2;
+        int32_t q;
 
-        int dcAmpsx100;
+        int32_t dcAmpsx100;
 
-        int pwm_limiter;
-        int pwm_requested;
-        int pwm_actual;
+        int32_t pwm_limiter;
+        int32_t pwm_requested;
+        int32_t pwm_actual;
 
-        unsigned int limiter_count;
+        uint32_t limiter_count;
 } PROTOCOL_MOTOR_ELECTRICAL;
 #pragma pack(pop)
 
 #pragma pack(push, 4) // all used types (float and int) are 4 bytes
 typedef struct tag_PROTOCOL_ELECTRICAL_PARAMS{
-    int bat_raw;
+    int32_t bat_raw;
     float batteryVoltage;
 
-    int board_temp_raw;
+    int32_t board_temp_raw;
     float board_temp_filtered;
     float board_temp_deg_c;
 
-    int charging;
+    int32_t charging;
 
-    int dcCurLim; // amps*100
-    int dc_adc_limit; // limit expressed in terms of ADC units.
+    int32_t dcCurLim; // amps*100
+    int32_t dc_adc_limit; // limit expressed in terms of ADC units.
 
     PROTOCOL_MOTOR_ELECTRICAL motors[2];
 
@@ -142,9 +142,9 @@ typedef struct tag_PROTOCOL_sensor_frame{
 
 #pragma pack(push, 4)  // since on 'long' are used, alignment can be optimized for 4 bytes
 typedef struct PROTOCOL_INTEGER_XYT_POSN_tag {
-    long x;
-    long y;
-    long degrees;
+    int32_t x;
+    int32_t y;
+    int32_t degrees;
 } PROTOCOL_INTEGER_XYT_POSN;
 #pragma pack(pop)
 
@@ -159,17 +159,17 @@ typedef struct {
 
 #pragma pack(push, 4)  // all used data types are 4 byte
 typedef struct tag_PROTOCOL_POSN {
-    long LeftAbsolute;
-    long RightAbsolute;
-    long LeftOffset;
-    long RightOffset;
+    int32_t LeftAbsolute;
+    int32_t RightAbsolute;
+    int32_t LeftOffset;
+    int32_t RightOffset;
 } PROTOCOL_POSN;
 #pragma pack(pop)
 
 #pragma pack(push, 4)  // all used data types are 4 byte
 typedef struct tag_PROTOCOL_POSN_INCR {
-    long Left;
-    long Right;
+    int32_t Left;
+    int32_t Right;
 } PROTOCOL_POSN_INCR;
 #pragma pack(pop)
 
@@ -227,16 +227,16 @@ typedef struct tag_MACHINE_PROTOCOL_TX_BUFFER {
 
 #pragma pack(push, 4) // all used data types are 4 byte
 typedef struct tag_PROTOCOLCOUNT {
-    unsigned long rx;              // Count of received messages (valid CS)
-    unsigned long rxMissing;       // If message IDs went missing..
-    unsigned long tx;              // Count of sent messages (ACK, NACK and retries do not count)
-    unsigned int  txRetries;       // how often were messages resend?
-    unsigned int  txFailed;        // TX Messages which couldn't be deliveredr. No retries left.
+    uint32_t rx;              // Count of received messages (valid CS)
+    uint32_t rxMissing;       // If message IDs went missing..
+    uint32_t tx;              // Count of sent messages (ACK, NACK and retries do not count)
+    uint32_t  txRetries;       // how often were messages resend?
+    uint32_t  txFailed;        // TX Messages which couldn't be deliveredr. No retries left.
 
-    unsigned int  unwantedacks;              // count of unwated ACK messages
-    unsigned int  unwantednacks;             // count of unwanted NACK messges
-    unsigned int  unknowncommands;           // count of messages with unknown commands
-    unsigned int  unplausibleresponse;       // count of unplausible replies
+    uint32_t  unwantedacks;              // count of unwated ACK messages
+    uint32_t  unwantednacks;             // count of unwanted NACK messges
+    uint32_t  unknowncommands;           // count of messages with unknown commands
+    uint32_t  unplausibleresponse;       // count of unplausible replies
 } PROTOCOLCOUNT;
 #pragma pack(pop)
 

--- a/protocol.h
+++ b/protocol.h
@@ -402,6 +402,14 @@ extern PARAMSTAT *params[256];
 
 
 
+///////////////////////////////////////////////////////
+// Function Pointers to system functions
+//////////////////////////////////////////////////////////
+
+// Need to be assigned to functions "real" system fucntions
+extern void (*protocol_Delay)(uint32_t Delay);
+extern void (*protocol_SystemReset)(void);
+extern uint32_t (*protocol_GetTick)(void);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Modified the protocol structures to work on a 64-bit system. The current version assumes `long` is 32-bit. However I made it on the commit that is referenced from `bipropellant-hoverboard-api`, therefore PR contains also latest commits from @p-h-a-i-l . Is that an issue?